### PR TITLE
LocalLibrary. Add Repository modules and injecting.

### DIFF
--- a/MyLibrary/Package.swift
+++ b/MyLibrary/Package.swift
@@ -19,6 +19,10 @@ let package = Package(
             targets: ["Model"]
         ),
         .library(
+            name: "Repository",
+            targets: ["Repository", "RepositoryImp"]
+        ),
+        .library(
             name: "ViewModel",
             targets: ["MyLibrary"]
         ),
@@ -34,16 +38,32 @@ let package = Package(
     ],
 
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "Model",
             path: "Model"
         ),
         .target(
+            name: "Repository",
+            dependencies: [
+                "Model",
+            ],
+            path: "Repository/Interface"
+        ),
+        .target(
+            name: "RepositoryImp",
+            dependencies: [
+                "Model",
+                "Repository",
+                .product(name: "RxSwift", package: "RxSwift"),
+            ],
+            path: "Repository/Implementation"
+        ),
+        .target(
             name: "MyLibrary",
             dependencies: [
                 "Model",
+                "Repository",
+                "RepositoryImp", // Temporal Import
                 .product(name: "Alamofire", package: "Alamofire"),
                 .product(name: "ReactorKit", package: "ReactorKit"),
                 .product(name: "RxCocoa", package: "RxSwift"),

--- a/MyLibrary/Repository/Implementation/TodoRepositoryImp.swift
+++ b/MyLibrary/Repository/Implementation/TodoRepositoryImp.swift
@@ -1,0 +1,20 @@
+import Model
+import Repository
+import RxSwift
+
+public class TodoRepositoryImp: TodoRepository {
+    public init() {}
+
+    public func fetch() -> Observable<[Todo]> {
+        return .just([
+            Todo(title: "물 3잔 마시기"),
+            Todo(title: "OO기업 자소서 쓰기", subTitle: "오늘까지", isComplete: true),
+        ])
+    }
+
+    public func create() {}
+
+    public func update() {}
+
+    public func delete() {}
+}

--- a/MyLibrary/Repository/Interface/TodoRepository.swift
+++ b/MyLibrary/Repository/Interface/TodoRepository.swift
@@ -1,0 +1,9 @@
+import Model
+import RxSwift
+
+public protocol TodoRepository {
+    func fetch() -> Observable<[Todo]>
+    func create()
+    func update()
+    func delete()
+}

--- a/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import ReactorKit
+import RepositoryImp
 import RxCocoa
 import RxSwift
 import TinyConstraints
@@ -53,7 +54,9 @@ public class HomeViewController: UICollectionViewController, View {
         
         initCollectionView()
         
-        self.bind(reactor: Reactor())
+        let reactor = Reactor(todoRepository: TodoRepositoryImp())
+        self.bind(reactor: reactor)
+        reactor.action.onNext(.initiate)
     }
     
     private func initCollectionView() {

--- a/MyLibrary/Sources/Libraries/HomeViewController/HomeViewReactor.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HomeViewReactor.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 import ReactorKit
+import Repository
 import RxSwift
 import Model
-
 
 public class HomeViewReactor: Reactor {
     
@@ -23,10 +23,12 @@ public class HomeViewReactor: Reactor {
     
     // MARK: - Constants
     public enum Action {
+        case initiate
         case cellSelected(IndexPath)
     }
     
     public enum Mutation {
+        case update(todos: [Todo])
         case setSelectedIndexPath(IndexPath?)
     }
     
@@ -35,15 +37,20 @@ public class HomeViewReactor: Reactor {
          var sections: [HomeSection]
     }
     
-    public init() {
-         self.initialState = State(
-         sections: HomeViewReactor.configSections()
-         )
+    private let todoRepository: TodoRepository
+    
+    public init(todoRepository: TodoRepository) {
+        self.todoRepository = todoRepository
+        self.initialState = State(
+            sections: HomeViewReactor.configSections()
+        )
     }
     
     // MARK: - func
     public func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .initiate:
+            return self.todoRepository.fetch().map { .update(todos: $0) }
         case .cellSelected(let indexPath):
             return Observable.concat([
                 Observable.just(Mutation.setSelectedIndexPath(indexPath)),
@@ -54,8 +61,10 @@ public class HomeViewReactor: Reactor {
     
     public func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
-        
         switch mutation {
+        case let .update(todos):
+            // TODO: Update newState
+            print(todos)
         case .setSelectedIndexPath(let indexPath):
             newState.selectedIndexPath = indexPath
         }


### PR DESCRIPTION
### LocalLibrary. Add Repository modules and injecting.

- `Repository` interface/implementation 모듈을 추가하고 `HomeViewReactor`에 주입하도록 수정하였습니다.
- 2단계에 걸쳐서 세라님이 이어서 수정을 하면 좋겠습니다.
  1. `TodoRepository`와 동일한 방식으로 `PlanRepository`를 추가하고 주입합니다.
  2. `HomeViewReactor.configSections()`를 제거하고, `reduce()` 내에서 state에 저장하도록 수정합니다.
- `HomeViewController`에서 `RepositoryImp`를 import 하고 있는 것은 추후에 없어질 예정입니다. 기본적으로 imp 모듈에 의존하는 것은 앱 뿐이고, 그 외의 모듈들은 interface에만 의존하는 것이 진행방향입니다.