### PR TITLE
FIX: Action.initiate로 api 호출합침 &  ADD: Plan Section에 카테고리 영역 추가

### DIFF
--- a/MyLibrary/Sources/Libraries/HomeViewController/CategoryCell.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/CategoryCell.swift
@@ -1,0 +1,99 @@
+//
+//  PlanListCell.swift
+//
+//
+//  Created by 박세라 on 4/3/24.
+//
+import UIKit
+import ReactorKit
+import TinyConstraints
+
+class CategoryCell: UICollectionViewCell {
+    // MARK: - view
+    private var items = [String]()
+    var segmentedControlButtons = [UIButton]()
+    
+    override func prepareForReuse() {
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc func handleSegmentedControlButtons(sender: UIButton) {
+        
+        for button in segmentedControlButtons {
+            if button == sender {
+                UIView.animate(withDuration: 0.2, delay: 0.1, options: .transitionFlipFromLeft) { [weak self] in
+                    button.backgroundColor = .black
+                }
+            } else {
+                UIView.animate(withDuration: 0.2, delay: 0.1, options: .transitionFlipFromLeft) { [weak self] in
+                    button.backgroundColor = .systemGray5
+                }
+            }
+        }
+    }
+    
+    func initCellWithItems(items: [String]) {
+        
+        self.items = items
+        self.segmentedControlButtons = self.items.map { UIButton().createSegmentedControlButton(setTitle: $0) }
+        
+        configureCustomsegmentedControl()
+        
+        // default checked : 카테고리 첫째 항목 선택으로 초기화
+        handleSegmentedControlButtons(sender: segmentedControlButtons[0])
+    }
+    
+    private func configureCustomsegmentedControl() {
+        
+        print("configureCustomsegmentedControl")
+        segmentedControlButtons.forEach { $0.addTarget(self, action: #selector(handleSegmentedControlButtons(sender:)), for: .touchUpInside)}
+        
+        let stackView = UIStackView(arrangedSubviews: segmentedControlButtons)
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        stackView.spacing = 8
+        
+        let scrollView = UIScrollView()
+        scrollView.contentSize = CGSize(width: .zero, height: 32)
+        scrollView.showsHorizontalScrollIndicator = false
+        
+        scrollView.addSubview(stackView)
+        
+        self.addSubview(scrollView)
+        
+        scrollView.topToSuperview()
+        scrollView.leadingToSuperview()
+        scrollView.trailingToSuperview()
+        scrollView.height(32)
+        
+        stackView.topToSuperview()
+        stackView.leadingToSuperview()
+        stackView.trailingToSuperview()
+        stackView.height(32)
+    }
+    
+}
+
+extension UIButton {
+    func createSegmentedControlButton(setTitle to: String) -> UIButton {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(to, for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.widthAnchor.constraint(equalToConstant: 90).isActive = true
+        button.heightAnchor.constraint(equalToConstant: 32).isActive = true
+        button.backgroundColor = UIColor.init(white: 0.1, alpha: 0.1)
+        button.layer.cornerRadius = 16
+        button.layer.borderWidth = 0.5
+        button.layer.borderColor = UIColor.white.cgColor
+        return button
+    }
+}
+    

--- a/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController+Section.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController+Section.swift
@@ -22,6 +22,7 @@ struct HomeSection {
 enum HomeSectionItem {
     case defaultCell(TodoListCellReactor)
     case planCell(PlanListCellReactor)
+    case categoryCell([String])
     // ...
 }
 extension HomeSection: SectionModelType {

--- a/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
@@ -56,8 +56,7 @@ public class HomeViewController: UICollectionViewController, View {
         
         let reactor = Reactor(todoRepository: TodoRepositoryImp(), planRepository: PlanRepositoryImp())
         self.bind(reactor: reactor)
-        reactor.action.onNext(.initiateTodo)
-        reactor.action.onNext(.initiatePlan)
+        reactor.action.onNext(.initiate)
         
     }
     

--- a/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
@@ -29,6 +29,10 @@ public class HomeViewController: UICollectionViewController, View {
             let cell = collectionView.dequeueReusableCell(TodoListCell.self, for: indexPath)
             cell.reactor = reactor
             return cell
+        case .categoryCell(let items):
+            let cell = collectionView.dequeueReusableCell(CategoryCell.self, for: indexPath)
+            cell.initCellWithItems(items: items)
+            return cell
         case .planCell(let reactor):
             let cell = collectionView.dequeueReusableCell(PlanListCell.self, for: indexPath)
             cell.reactor = reactor
@@ -62,6 +66,7 @@ public class HomeViewController: UICollectionViewController, View {
     
     private func initCollectionView() {
         self.collectionView.register(TodoListCell.self)
+        self.collectionView.register(CategoryCell.self)
         self.collectionView.register(PlanListCell.self)
         self.collectionView.register(HeaderCell.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "HeaderCell")
         
@@ -106,12 +111,13 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
     // TODO: 유동적인 높이 구현.
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
-        switch indexPath.section {
-        case 0:
+        switch dataSource.sectionModels[indexPath.section].items[indexPath.item] {
+        case .defaultCell(_):
             return CGSize(width: UIScreen.main.bounds.width - 32.0, height: 44)
-        case 1:
+        case .categoryCell(_):
+            return CGSize(width: UIScreen.main.bounds.width - 32.0, height: 32)
+        case .planCell(_):
             return CGSize(width: (UIScreen.main.bounds.width - 44.0) / 2, height: (UIScreen.main.bounds.width - 44.0) * 0.6 )
-        default: return CGSize(width: UIScreen.main.bounds.width - 32.0, height: 44)
         }
     }
     
@@ -120,18 +126,17 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
         case UICollectionView.elementKindSectionHeader:
             let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "HeaderCell", for: indexPath) as! HeaderCell
             return header
-            /*
-             case UICollectionView.elementKindSectionFooter:
-             let footer = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "MyHeaderFooterView", for: indexPath) as! MyHeaderFooterView
-             return footer
-             */
         default:
             return UICollectionReusableView()
         }
     }
     public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         let width: CGFloat = collectionView.frame.width
-        let height: CGFloat = 60
+        var height: CGFloat = 60
+        // header가 없을 경우 default Header Height 설정
+        if dataSource.sectionModels[section].header == "" {
+            height = 16
+        }
         return CGSize(width: width, height: height)
     }
 }

--- a/MyLibrary/Sources/Libraries/HomeViewController/HomeViewReactor.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HomeViewReactor.swift
@@ -67,27 +67,30 @@ public class HomeViewReactor: Reactor {
         var newState = state
         switch mutation {
         case let .update(todos, plans):
-            // TODO: Update newState
             let todoCells = todos.map {
                 HomeSectionItem.defaultCell(TodoListCellReactor(state: $0))
             }
-            let planCells = plans.map {
+            var planCells = plans.map {
                 HomeSectionItem.planCell(PlanListCellReactor(state: $0))
             }
             
+            // TODO: Category도 Model화 작업 예정.
+            var categoryCells = [HomeSectionItem.categoryCell(["독서", "언어", "운동", "여행", "공부", "계획"])]
+            
+            categoryCells.append(contentsOf: planCells)
+            
             let todoList = HomeSection(header: "Todo", items: todoCells)
-            let planList = HomeSection(header: "Plan", items: planCells)
+            let planList = HomeSection(header: "Plan", items: categoryCells)
             
             if !todos.isEmpty {
                 sections.append(todoList)
             }
+            
             if !plans.isEmpty {
                 sections.append(planList)
             }
             newState.sections = sections
             
-            print(sections)
-           
         case .setSelectedIndexPath(let indexPath):
             newState.selectedIndexPath = indexPath
         

--- a/MyLibrary/Sources/Libraries/HomeViewController/PlanListCell.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/PlanListCell.swift
@@ -24,8 +24,6 @@ class PlanListCell: UICollectionViewCell, View {
     let progressBaseView = UIView()
     
     override func prepareForReuse() {
-        print(progressBaseView.frame.width)
-        print(progressBaseView.bounds.width)
     }
     
     override init(frame: CGRect) {


### PR DESCRIPTION
- Action을 `Action.initiate` 하나로 줄였습니다.
- `mutate()`에서 `Oberservable.merge`를 사용하고, todos와 plans의 `Observable Array`를 return 하게끔 수정했습니다. 
   ㄴ `reduce()`에서 todos와 plans가 비어있는 지 확인 후에 setions에 넣게 구현했습니다.
- `for-in` 구문을 삭제하고 `map()`를 사용해 sectionItem을 추가했습니다.