### PR TITLE
Feat4: 메모생성화면 이동

### DIFF
--- a/MemoZip/MemoZip/AppDelegate.swift
+++ b/MemoZip/MemoZip/AppDelegate.swift
@@ -19,23 +19,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         
         window = UIWindow(frame: UIScreen.main.bounds)
-        /*
-        let flowLayout = UICollectionViewFlowLayout()
         
-        let mainViewController = ReminderListViewController(collectionViewLayout: flowLayout) // 맨 처음 보여줄 ViewController
-        
-        // 앱을 시작할 때 루트 뷰 컨트롤러를 생성하고 UINavigationController에 추가합니다.
-        let navigationController = UINavigationController(rootViewController : mainViewController) // 실제로 사용하는 뷰 컨트롤러의 클래스명
-        
-        // NavigationController에 처음으로 보여질 화면을 rootView로 지정
-        window?.rootViewController = navigationController
-        window?.makeKeyAndVisible()
-         */
         let tabBarController = UITabBarController()
         
         let reminderListViewController = UINavigationController(rootViewController: ReminderListViewController(collectionViewLayout: UICollectionViewFlowLayout()))
         
-        //let reactor = HomeViewReactor()
         let homeViewController = UINavigationController(rootViewController:  HomeViewController(collectionViewLayout: UICollectionViewFlowLayout()))
         
         tabBarController.setViewControllers([homeViewController, reminderListViewController], animated: true)

--- a/MyLibrary/Sources/Libraries/AddMemoViewController/AddMemoViewController.swift
+++ b/MyLibrary/Sources/Libraries/AddMemoViewController/AddMemoViewController.swift
@@ -1,0 +1,18 @@
+//
+//  AddMemoViewController.swift
+//
+//
+//  Created by 박세라 on 4/24/24.
+//
+
+import Foundation
+import UIKit
+
+
+public class AddMemoViewController: UIViewController {
+    
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        print("AddMemoViewController viewDidLoad")
+    }
+}

--- a/MyLibrary/Sources/Libraries/HomeViewController/HeaderCell.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HeaderCell.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 import ReactorKit
+import RxSwift
+import RxCocoa
 import ViewModel
 import ViewModelImp
 
@@ -20,17 +22,27 @@ class HeaderCell: UICollectionReusableView, View {
     // MARK: - view
     let titleLabel = UILabel()
     
+    var addButton = UIButton()
     // ...
+    
+    var voidHandler: (() -> ())?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         self.addSubview(titleLabel)
+        self.addSubview(addButton)
         
         titleLabel.numberOfLines = 0
         titleLabel.font = UIFont.systemFont(ofSize: 24, weight: .bold)
         titleLabel.left(to: self, offset: 8)
         titleLabel.centerYToSuperview()
+        
+        addButton.setImage(UIImage(systemName: "plus.app"), for: .normal)
+        addButton.height(20)
+        addButton.width(20)
+        addButton.centerYToSuperview()
+        addButton.right(to: self, offset: -8)
         
     }
     
@@ -38,8 +50,24 @@ class HeaderCell: UICollectionReusableView, View {
         fatalError("init(coder:) has not been implemented")
     }
     
-    
     func bind(reactor: HeaderCellReactor) {
-        self.titleLabel.text = reactor.currentState.title
+        
+        titleLabel.text = reactor.initialState.headerTitle
+        
+        addButton.rx.tap
+            .map{ _ in Reactor.Action.buttonTapped}
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.isButtonTapped }
+            .distinctUntilChanged()
+            .subscribe(onNext: { [weak self] isTapped in
+                // 버튼의 상태에 따라 UI 업데이트 로직 수행
+                //HomeViewReactor.Action.addItem()
+                self?.voidHandler?()
+            })
+            .disposed(by: disposeBag)
+        
+        
     }
 }

--- a/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
@@ -47,7 +47,22 @@ public class HomeViewController: UICollectionViewController, View {
             guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "HeaderCell", for: indexPath) as? HeaderCell else {
                 return UICollectionReusableView()
             }
-            header.reactor = HeaderCellReactor(state: Title(title: dataSource[indexPath.section].header))
+            
+            header.reactor = HeaderCellReactor(headerTitle: dataSource[indexPath.section].header)
+            header.voidHandler = {
+                print("voidHandler, indexPath:\(indexPath)")
+                //guard let self = self else { return }
+                let viewController = AddMemoViewController()
+                
+                let navigationController = UINavigationController(rootViewController: viewController)
+                
+                let window = UIWindow(frame: UIScreen.main.bounds)
+                
+                window.rootViewController = navigationController
+                
+                window.makeKeyAndVisible()
+            }
+            
             return header
         default:
             assert(false, "Unexpected element kind")
@@ -88,12 +103,23 @@ public class HomeViewController: UICollectionViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        
+        
+        
         // state
         reactor.state.map { $0.selectedIndexPath }
             .compactMap { $0 }
             .subscribe(onNext: { [weak self] indexPath in
                 guard let self = self else { return }
                 self.collectionView.deselectItem(at: indexPath, animated: true)
+            }).disposed(by: disposeBag)
+        
+        reactor.state.map { $0.move }
+            .compactMap{ $0 }
+            .subscribe(onNext: { [weak self ] indexPath in
+                guard let self = self else { return }
+                let viewController = AddMemoViewController()
+                self.navigationController?.pushViewController(viewController, animated: true)
             }).disposed(by: disposeBag)
         
         

--- a/MyLibrary/ViewModel/Implementation/HeaderCellReactor.swift
+++ b/MyLibrary/ViewModel/Implementation/HeaderCellReactor.swift
@@ -8,16 +8,52 @@
 
 import Foundation
 import ReactorKit
+import RxSwift
+import RxCocoa
 import Model
 
 public class HeaderCellReactor: Reactor {
     
-    public typealias Action = NoAction
+    public enum Action {
+        case initiate
+        case buttonTapped
+    }
     
-    // MARK: - Property
-    public let initialState: Title
+    public enum Mutation {
+        case update(String)
+        case setButtonTapped(Bool)
+    }
     
-    public init(state: Title) {
-        self.initialState = state
+    public struct State {
+        public var headerTitle: String = ""
+        public var isButtonTapped: Bool = false
+    }
+    
+    public let initialState: State
+    
+    public init(headerTitle: String) {
+        self.initialState = State(
+            headerTitle: headerTitle
+            )
+    }
+    
+    public func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .initiate:
+            return .just(.update(initialState.headerTitle))
+        case .buttonTapped:
+            return .just(.setButtonTapped(true))
+        }
+    }
+    
+    public func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .update(let title):
+            newState.headerTitle = title
+        case .setButtonTapped(let isTapped):
+            newState.isButtonTapped = isTapped
+        }
+        return newState
     }
 }

--- a/MyLibrary/ViewModel/Implementation/HomeViewReactor.swift
+++ b/MyLibrary/ViewModel/Implementation/HomeViewReactor.swift
@@ -26,16 +26,19 @@ public class HomeViewReactor: Reactor {
     public enum Action {
         case initiate
         case cellSelected(IndexPath)
+        case addItem(IndexPath)
     }
     
     public enum Mutation {
         case update(todos: [Todo], plans: [Plan])
         case setSelectedIndexPath(IndexPath?)
+        case showAddViewController(IndexPath?)
     }
     
     public struct State {
-         public var selectedIndexPath: IndexPath?
-         public var sections: [HomeSection]
+        public var selectedIndexPath: IndexPath?
+        public var sections: [HomeSection]
+        public var move: IndexPath?
     }
     
     private let todoRepository: TodoRepository
@@ -60,6 +63,11 @@ public class HomeViewReactor: Reactor {
             return Observable.concat([
                 Observable.just(Mutation.setSelectedIndexPath(indexPath)),
                 Observable.just(Mutation.setSelectedIndexPath(nil))
+            ])
+        case .addItem(let indexPath):
+            return Observable.concat([
+                Observable.just(Mutation.showAddViewController(indexPath)),
+                Observable.just(Mutation.showAddViewController(nil))
             ])
         }
     }
@@ -94,7 +102,8 @@ public class HomeViewReactor: Reactor {
             
         case .setSelectedIndexPath(let indexPath):
             newState.selectedIndexPath = indexPath
-        
+        case .showAddViewController(let indexPath):
+            newState.move = indexPath
         }
         return newState
     }


### PR DESCRIPTION
- 홈화면에서 `HeaderCell`의 버튼 클릭시 `AddMemoViewController`로 이동하려고 `self.navigationController.pushViewController(viewController, animated: true)`코드를 작성했는데 아래와 같은 오류가 납니다.
<img width="588" alt="스크린샷 2024-04-29 오후 7 25 31" src="https://github.com/f-lab-edu/MemoZip/assets/100737771/91ff3897-db1c-408e-af80-ffa89cdbceb8">
AppDelegate에서 HomeViewController를 UINavigationController로 감싸서 present 시켜줬는데, self.navigationController가 왜 없다고 나오는 건지.. 궁금합니다.

그래서 이동을 어떻게든 시키려고 아래와 같이 코드를 작성했는데, 새로운 화면으로 이동하지는 않았습니다.
```
let viewController = AddMemoViewController()
                
                let navigationController = UINavigationController(rootViewController: viewController)
                
                let window = UIWindow(frame: UIScreen.main.bounds)
                
                window.rootViewController = navigationController
                
                window.makeKeyAndVisible()
```