### PR TITLE
ReactorInjection. Remove Reactor.View and inject the reactor.

### DIFF
--- a/MemoZip/MemoZip.xcodeproj/project.pbxproj
+++ b/MemoZip/MemoZip.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3822E6DE2BDFA394001F9C2C /* AppComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3822E6DD2BDFA394001F9C2C /* AppComponent.swift */; };
 		3871E2A42BC86154006AD761 /* LocalLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = 3871E2A32BC86154006AD761 /* LocalLibrary */; };
 		A40D528A2BA873B5006C7497 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40D52892BA873B5006C7497 /* AppDelegate.swift */; };
 		A4AB4ACB2BA8608C00CD1104 /* MyLibrary in Sources */ = {isa = PBXBuildFile; fileRef = A4AB4ACA2BA8607000CD1104 /* MyLibrary */; };
@@ -14,6 +15,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3822E6DD2BDFA394001F9C2C /* AppComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppComponent.swift; sourceTree = "<group>"; };
 		A40D52892BA873B5006C7497 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A4AB4ACA2BA8607000CD1104 /* MyLibrary */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = MyLibrary; path = ../MyLibrary; sourceTree = "<group>"; };
 		A4DE741A2B9C45A200D9ABF1 /* MemoZip.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MemoZip.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -62,6 +64,7 @@
 			isa = PBXGroup;
 			children = (
 				A40D52892BA873B5006C7497 /* AppDelegate.swift */,
+				3822E6DD2BDFA394001F9C2C /* AppComponent.swift */,
 				A4DE74282B9C45A300D9ABF1 /* LaunchScreen.storyboard */,
 				A4DE742B2B9C45A300D9ABF1 /* Info.plist */,
 			);
@@ -144,6 +147,7 @@
 			files = (
 				A40D528A2BA873B5006C7497 /* AppDelegate.swift in Sources */,
 				A4AB4ACB2BA8608C00CD1104 /* MyLibrary in Sources */,
+				3822E6DE2BDFA394001F9C2C /* AppComponent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MemoZip/MemoZip/AppComponent.swift
+++ b/MemoZip/MemoZip/AppComponent.swift
@@ -1,0 +1,24 @@
+import Repository
+import RepositoryImp
+import UIKit
+import ViewModel
+import ViewModelImp
+import MyLibrary // => UI, View 혹은 Feature 같은 이름으로 변경 필요.
+
+final class AppComponent {
+    private let todoRepository: TodoRepository
+    private let planRepository: PlanRepository
+
+    init() {
+        self.todoRepository = TodoRepositoryImp()
+        self.planRepository = PlanRepositoryImp()
+    }
+
+    func homeViewController() -> UIViewController {
+        let reactor = HomeViewReactor(
+            todoRepository: self.todoRepository,
+            planRepository: self.planRepository
+        )
+        return HomeViewController(reactor: reactor)
+    }
+}

--- a/MemoZip/MemoZip/AppDelegate.swift
+++ b/MemoZip/MemoZip/AppDelegate.swift
@@ -15,6 +15,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?        // window 프로퍼티 추가
     
+    private let appComponent = AppComponent()
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         
@@ -33,12 +35,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          */
         let tabBarController = UITabBarController()
         
-        let reminderListViewController = UINavigationController(rootViewController: ReminderListViewController(collectionViewLayout: UICollectionViewFlowLayout()))
+        let reminderListViewController = ReminderListViewController(collectionViewLayout: UICollectionViewFlowLayout())
         
-        //let reactor = HomeViewReactor()
-        let homeViewController = UINavigationController(rootViewController:  HomeViewController(collectionViewLayout: UICollectionViewFlowLayout()))
+        let homeViewController = self.appComponent.homeViewController()
         
-        tabBarController.setViewControllers([homeViewController, reminderListViewController], animated: true)
+        let viewControllers = [homeViewController, reminderListViewController].map { UINavigationController(rootViewController: $0) }
+        tabBarController.setViewControllers(viewControllers, animated: true)
         
         if let items = tabBarController.tabBar.items {
             items[0].selectedImage = UIImage(systemName: "house.fill")

--- a/MyLibrary/Package.swift
+++ b/MyLibrary/Package.swift
@@ -53,6 +53,7 @@ let package = Package(
             name: "Repository",
             dependencies: [
                 "Model",
+                .product(name: "RxSwift", package: "RxSwift"),
             ],
             path: "Repository/Interface"
         ),

--- a/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import ReactorKit
-import RepositoryImp
 import RxCocoa
 import RxSwift
 import TinyConstraints
@@ -18,11 +17,12 @@ import ViewModel
 
 typealias ManageMentDataSource = RxCollectionViewSectionedReloadDataSource<HomeSection>
 
-public class HomeViewController: UICollectionViewController, View {
+public class HomeViewController: UICollectionViewController {
     
-    public typealias Reactor = HomeViewReactor
+    typealias Reactor = HomeViewReactor
     
-    public var disposeBag = DisposeBag()
+    private let reactor: Reactor
+    private var disposeBag: DisposeBag = .init()
 
     let dataSource = RxCollectionViewSectionedReloadDataSource<HomeSection>(configureCell: { dataSource, collectionView, indexPath, item in
         
@@ -54,16 +54,25 @@ public class HomeViewController: UICollectionViewController, View {
         }
     })
     
+    public init(reactor: HomeViewReactor) {
+        self.reactor = reactor
+        let layout = UICollectionViewFlowLayout()
+        super.init(collectionViewLayout: layout)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     
     public override func viewDidLoad() {
         super.viewDidLoad()
         
         initCollectionView()
         
-        let reactor = Reactor(todoRepository: TodoRepositoryImp(), planRepository: PlanRepositoryImp())
-        self.bind(reactor: reactor)
-        reactor.action.onNext(.initiate)
+        bindReactor()
         
+        reactor.action.onNext(.initiate)
     }
     
     private func initCollectionView() {
@@ -80,7 +89,7 @@ public class HomeViewController: UICollectionViewController, View {
         collectionView.contentInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
     }
     
-    public func bind(reactor: HomeViewReactor) {
+    public func bindReactor() {
         
         // action
         collectionView.rx.itemSelected


### PR DESCRIPTION
### ReactorInjection. Remove Reactor.View and inject the reactor.

- `Reactor.View` protocol이 reactor를 생성자를 통해 주입 받는 것을 방해하는 느낌이 듭니다. `Reactor.View`의 extension 구현을 보면, reactor의 setter에서 bind()를 무조건 호출하도록 되어 있습니다. 이 때문에 reactor에 값을 할당하기 전에 view setup이 끝나 있어야하기 때문에, 생성자 내에서 view setup을 해야만 합니다.
- `Reactor.View`의 conformance를 제거하고, Reactor를 App에서 주입하도록 수정하였습니다. `reactor` 프로퍼티는 명시적으로 선언하였습니다.
- 앞으로 의존성의 주입을 담당할 `AppComponent`를 추가하였습니다. `ReminderListViewController`의 사용도 유사한 방식으로 수정해보면 좋겠습니다.
- 현재 작성하신 PR #16 과 `AppDelegate` 쪽에 충돌이 있을 것 같네요. 이 PR을 머지 후, rebase 하면서 충돌을 해소해보면 좋겠습니다.