### PR TITLE
AppComponent. Inject HomeRouting.

### DIFF
--- a/MemoZip/MemoZip/AppComponent.swift
+++ b/MemoZip/MemoZip/AppComponent.swift
@@ -5,7 +5,10 @@ import ViewModel
 import ViewModelImp
 import MyLibrary // => UI, View 혹은 Feature 같은 이름으로 변경 필요.
 
-final class AppComponent {
+typealias AppRouting =
+    HomeRouting
+
+final class AppComponent: AppRouting {
     private let todoRepository: TodoRepository
     private let planRepository: PlanRepository
 
@@ -19,6 +22,10 @@ final class AppComponent {
             todoRepository: self.todoRepository,
             planRepository: self.planRepository
         )
-        return HomeViewController(reactor: reactor)
+        return HomeViewController(reactor: reactor, routing: self)
+    }
+    
+    func addMemoViewController() -> UIViewController {
+        return AddMemoViewController()
     }
 }

--- a/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
@@ -15,7 +15,9 @@ import Model
 import ViewModelImp
 import ViewModel
 
-typealias ManageMentDataSource = RxCollectionViewSectionedReloadDataSource<HomeSection>
+public protocol HomeRouting {
+    func addMemoViewController() -> UIViewController
+}
 
 public class HomeViewController: UICollectionViewController {
     
@@ -23,8 +25,10 @@ public class HomeViewController: UICollectionViewController {
     
     private let reactor: Reactor
     private var disposeBag: DisposeBag = .init()
+    private let routing: HomeRouting
 
-    let dataSource = RxCollectionViewSectionedReloadDataSource<HomeSection>(configureCell: { dataSource, collectionView, indexPath, item in
+    typealias DataSource = RxCollectionViewSectionedReloadDataSource<HomeSection>
+    lazy var dataSource = DataSource(configureCell: { dataSource, collectionView, indexPath, item in
         
         switch item {
         case .defaultCell(let reactor):
@@ -69,8 +73,9 @@ public class HomeViewController: UICollectionViewController {
         }
     })
     
-    public init(reactor: HomeViewReactor) {
+    public init(reactor: HomeViewReactor, routing: HomeRouting) {
         self.reactor = reactor
+        self.routing = routing
         let layout = UICollectionViewFlowLayout()
         super.init(collectionViewLayout: layout)
     }
@@ -127,7 +132,7 @@ public class HomeViewController: UICollectionViewController {
             .compactMap{ $0 }
             .subscribe(onNext: { [weak self ] indexPath in
                 guard let self = self else { return }
-                let viewController = AddMemoViewController()
+                let viewController = self.routing.addMemoViewController()
                 self.navigationController?.pushViewController(viewController, animated: true)
             }).disposed(by: disposeBag)
         


### PR DESCRIPTION
### AppComponent. Inject HomeRouting.

- 다른 화면으로의 이동하기 위해 해당 ViewController를 직접 생성하게 되면, 두 ViewController 사이에 의존성이 생기게 됩니다. 
- 이 같은 의존성을 끊기 위해 `HomeRouting` protocol을 정의하고, 이를 주입 받는 방식으로 개선해보았습니다.
- 아직 `AddMemoViewController`로 진입이 안되는 부분은 동일한데, `lazy` 키워드에 대한 조사 후 직접 수정하실 수 있도록 일단 그대로 놔뒀습니다.