### PR TITLE
화면이동

### DIFF
--- a/MyLibrary/Sources/Libraries/HomeViewController/HeaderCell.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HeaderCell.swift
@@ -25,8 +25,6 @@ class HeaderCell: UICollectionReusableView, View {
     var addButton = UIButton()
     // ...
     
-    var voidHandler: (() -> ())?
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -53,21 +51,6 @@ class HeaderCell: UICollectionReusableView, View {
     func bind(reactor: HeaderCellReactor) {
         
         titleLabel.text = reactor.initialState.headerTitle
-        
-        addButton.rx.tap
-            .map{ _ in Reactor.Action.buttonTapped}
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
-        reactor.state.map { $0.isButtonTapped }
-            .distinctUntilChanged()
-            .subscribe(onNext: { [weak self] isTapped in
-                // 버튼의 상태에 따라 UI 업데이트 로직 수행
-                //HomeViewReactor.Action.addItem()
-                self?.voidHandler?()
-            })
-            .disposed(by: disposeBag)
-        
         
     }
 }

--- a/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
+++ b/MyLibrary/Sources/Libraries/HomeViewController/HomeViewController.swift
@@ -48,28 +48,24 @@ public class HomeViewController: UICollectionViewController {
         
         switch kind {
         case UICollectionView.elementKindSectionHeader:
+            // 재사용 가능한 헤더셀을 가져옴
             guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "HeaderCell", for: indexPath) as? HeaderCell else {
                 return UICollectionReusableView()
             }
             
             header.reactor = HeaderCellReactor(headerTitle: dataSource[indexPath.section].header)
-            header.voidHandler = {
-                print("voidHandler, indexPath:\(indexPath)")
-                //guard let self = self else { return }
-                let viewController = AddMemoViewController()
-                
-                let navigationController = UINavigationController(rootViewController: viewController)
-                
-                let window = UIWindow(frame: UIScreen.main.bounds)
-                
-                window.rootViewController = navigationController
-                
-                window.makeKeyAndVisible()
-            }
+        
+            header.addButton.rx.tap
+                .subscribe(onNext: { [weak self] in
+                    guard let self = self else { return }
+                    self.reactor.action.onNext(.addItem(indexPath))
+                })
+                .disposed(by: header.disposeBag)
             
             return header
         default:
             assert(false, "Unexpected element kind")
+            return UICollectionReusableView()
         }
     })
     
@@ -116,8 +112,6 @@ public class HomeViewController: UICollectionViewController {
             .map{ Reactor.Action.cellSelected($0)}
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
-        
         
         
         // state


### PR DESCRIPTION
- AddMemoViewController로 진입되게 수정
  - [#18](https://github.com/f-lab-edu/MemoZip/pull/18)과 [#16](https://github.com/f-lab-edu/MemoZip/pull/16)을 참고하여 수정했습니다.
  - `voidHandler`를 삭제하고, `header.addButton.rx.tap`를 통해 `self.reactor.action.onNext(.addItem(indexPath))`을 호출하는 방식으로 수정했습니다.
  - ` lazy var dataSource = DataSource(configureCell: { dataSource, collectionView, indexPath, item in` :  `lazy` 사용으로, 객체가 사용될때 초기화 하여 `self.reactor`에 접근할 수 있습니다.