### PR TITLE
FIX: routing.addMemoViewController()의 parameter로 handler를 전달

### DIFF
--- a/MemoZip/MemoZip/AppComponent.swift
+++ b/MemoZip/MemoZip/AppComponent.swift
@@ -4,18 +4,17 @@ import UIKit
 import ViewModel
 import View
 
-typealias AppRouting =
-    HomeRouting
+typealias AppRouting = HomeRouting
 
 final class AppComponent: AppRouting {
     private let todoRepository: TodoRepository
     private let planRepository: PlanRepository
-
+    
     init() {
         self.todoRepository = TodoRepositoryImp()
         self.planRepository = PlanRepositoryImp()
     }
-
+    
     func homeViewController() -> UIViewController {
         let reactor = HomeViewReactor(
             todoRepository: self.todoRepository,

--- a/MemoZip/MemoZip/AppComponent.swift
+++ b/MemoZip/MemoZip/AppComponent.swift
@@ -24,7 +24,9 @@ final class AppComponent: AppRouting {
         return HomeViewController(reactor: reactor, routing: self)
     }
     
-    func addMemoViewController() -> UIViewController {
-        return AddMemoViewController()
+    func addMemoViewController(messageHandler: @escaping (String) -> ()) -> UIViewController {
+        let addMemoVC = AddMemoViewController()
+        addMemoVC.messageHandler = messageHandler
+        return addMemoVC
     }
 }

--- a/MyLibrary/View/AddMemoViewController/AddMemoViewController.swift
+++ b/MyLibrary/View/AddMemoViewController/AddMemoViewController.swift
@@ -13,7 +13,7 @@ import TinyConstraints
 public class AddMemoViewController: UIViewController {
 
     // MARK: - Properties
-    var addMemoHandler: (([String: Any]) -> ())?
+    public var messageHandler: ((String)-> ())?
     
     // MARK: UI Components
     var stackView: UIStackView = {
@@ -85,9 +85,6 @@ public class AddMemoViewController: UIViewController {
         initView()
         
         setAction()
-        
-        
-        
     }
     
     private func initView() {
@@ -139,15 +136,13 @@ public class AddMemoViewController: UIViewController {
     }
     
     @objc func submitValue() {
-        print("submitValue")
         guard let memo = textView.text else { return }
-        self.addMemoHandler?(["result": true, "memo": memo])
+        messageHandler?(memo)
         self.dismiss(animated: true)
     }
     
     // 화면 종료 함수
     @objc func dismissView() {
-        self.addMemoHandler?(["result": false, "memo": ""])
         self.dismiss(animated: true)
     }
 }

--- a/MyLibrary/View/AddMemoViewController/AddMemoViewController.swift
+++ b/MyLibrary/View/AddMemoViewController/AddMemoViewController.swift
@@ -1,8 +1,8 @@
 //
-//  AddMemoViewController.swift
+// AddMemoViewController.swift
 //
 //
-//  Created by 박세라 on 4/24/24.
+// Created by 박세라 on 4/24/24.
 //
 
 import Foundation
@@ -11,7 +11,7 @@ import TinyConstraints
 
 
 public class AddMemoViewController: UIViewController {
-
+    
     // MARK: - Properties
     public var messageHandler: ((String)-> ())?
     

--- a/MyLibrary/View/HomeViewController/HomeViewController.swift
+++ b/MyLibrary/View/HomeViewController/HomeViewController.swift
@@ -15,7 +15,8 @@ import Model
 import ViewModel
 
 public protocol HomeRouting {
-    func addMemoViewController() -> UIViewController
+    func addMemoViewController(messageHandler: @escaping (String) -> ()) -> UIViewController
+    
 }
 
 public class HomeViewController: UICollectionViewController {
@@ -125,14 +126,8 @@ public class HomeViewController: UICollectionViewController {
             .compactMap{ $0 }
             .subscribe(onNext: { [weak self ] indexPath in
                 guard let self = self else { return }
-                let viewController = self.routing.addMemoViewController() as! AddMemoViewController
-                //self.navigationController?.pushViewController(viewController, animated: true)
-                viewController.addMemoHandler = { [weak self] result in
-                    if let addMemoResult = result["result"] as? Bool, let memo = result["memo"] as? String {
-                        print("addMemoResult:\(addMemoResult), memo:\(memo)")
-                    } else {
-                        // error
-                    }
+                let viewController = self.routing.addMemoViewController { [weak self] memo in
+                    print("memo: \(memo)")
                 }
                 self.present(viewController, animated: true)
             }).disposed(by: disposeBag)

--- a/MyLibrary/View/HomeViewController/HomeViewController.swift
+++ b/MyLibrary/View/HomeViewController/HomeViewController.swift
@@ -1,8 +1,8 @@
 //
-//  HomeViewController.swift
-//  MemoZip
+// HomeViewController.swift
+// MemoZip
 //
-//  Created by 박세라 on 3/9/24.
+// Created by 박세라 on 3/9/24.
 //
 
 import UIKit
@@ -26,7 +26,7 @@ public class HomeViewController: UICollectionViewController {
     private let reactor: Reactor
     private var disposeBag: DisposeBag = .init()
     private let routing: HomeRouting
-
+    
     typealias DataSource = RxCollectionViewSectionedReloadDataSource<HomeSection>
     lazy var dataSource = DataSource(configureCell: { dataSource, collectionView, indexPath, item in
         
@@ -54,7 +54,7 @@ public class HomeViewController: UICollectionViewController {
             }
             
             header.reactor = HeaderCellReactor(headerTitle: dataSource[indexPath.section].header)
-        
+            
             header.addButton.rx.tap
                 .subscribe(onNext: { [weak self] in
                     guard let self = self else { return }
@@ -138,10 +138,10 @@ public class HomeViewController: UICollectionViewController {
             .asObservable()
             .bind(to: self.collectionView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
-    
-         
+        
+        
     }
-
+    
 }
 
 extension HomeViewController: UICollectionViewDelegateFlowLayout {


### PR DESCRIPTION
[PR #25](https://github.com/f-lab-edu/MemoZip/pull/25)
- `routing.addMemoViewController()`의 parameter로 handler를 전달
- `addMemoHandler` [String: Any] -> () 를 `messageHandler` -> (String)-> () 으로 수정
