### PR TITLE
#33 <<< Implement PlanTypesCell.

### DIFF
--- a/MyLibrary/Model/Plan.swift
+++ b/MyLibrary/Model/Plan.swift
@@ -21,7 +21,7 @@ public enum Plan {
     }
 }
 
-public enum PlanType: Int {
+public enum PlanType: CaseIterable {
     case memo
     case book
 }

--- a/MyLibrary/View/HomeViewController/HomeViewController.swift
+++ b/MyLibrary/View/HomeViewController/HomeViewController.swift
@@ -42,7 +42,15 @@ public class HomeViewController: UICollectionViewController {
             cell.initCellWithItems(items: items)
             cell.selectedHandler = { [weak self] catIndex in // 선택된 카테고리 index
                 guard let self = self else { return }
-                self.reactor.action.onNext(.categorySelected(catIndex))
+                let selectedPlanType = PlanType.allCases[catIndex]
+                self.reactor.action.onNext(.planTypeSelected(selectedPlanType))
+            }
+            return cell
+        case let .planTypesCell(planType):
+            let cell = collectionView.dequeueReusableCell(PlanTypesCell.self, for: indexPath)
+            cell.configure(selectedPlanType: planType)
+            cell.selectionHandler = { [weak self] selectedPlanType in // 선택된 카테고리 index
+                self?.reactor.action.onNext(.planTypeSelected(selectedPlanType))
             }
             return cell
         case .bookCell(let reactor):
@@ -104,6 +112,7 @@ public class HomeViewController: UICollectionViewController {
     private func initCollectionView() {
         self.collectionView.register(TodoListCell.self)
         self.collectionView.register(CategoryCell.self)
+        self.collectionView.register(PlanTypesCell.self)
         self.collectionView.register(BookListCell.self)
         self.collectionView.register(MemoListCell.self)
         self.collectionView.register(HeaderCell.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: "HeaderCell")
@@ -187,7 +196,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
         switch dataSource.sectionModels[indexPath.section].items[indexPath.item] {
         case .defaultCell(_):
             return CGSize(width: UIScreen.main.bounds.width - 32.0, height: 44)
-        case .categoryCell(_):
+        case .categoryCell, .planTypesCell:
             return CGSize(width: UIScreen.main.bounds.width - 32.0, height: 32)
         case .bookCell(_):
             return CGSize(width: (UIScreen.main.bounds.width - 44.0) / 2, height: (UIScreen.main.bounds.width - 44.0) * 0.6 )

--- a/MyLibrary/View/HomeViewController/PlanTypesCell.swift
+++ b/MyLibrary/View/HomeViewController/PlanTypesCell.swift
@@ -1,0 +1,94 @@
+import Model
+import TinyConstraints
+import UIKit
+
+final class PlanTypesCell: UICollectionViewCell {
+    
+    private let planTypes: [PlanType] = PlanType.allCases
+    private let selectedPlanType: PlanType = .memo
+    var selectionHandler: ((PlanType) -> ())?
+    
+    private var planTypeButtons: [PlanTypeButton]!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupViews() {
+        let scrollView = UIScrollView()
+        scrollView.showsHorizontalScrollIndicator = false
+        self.contentView.addSubview(scrollView)
+        scrollView.topToSuperview()
+        scrollView.horizontalToSuperview()
+        scrollView.height(32)
+        
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .fillEqually
+        stackView.spacing = 8
+        scrollView.addSubview(stackView)
+        stackView.topToSuperview()
+        stackView.horizontalToSuperview()
+        stackView.height(32)
+        
+        let planTypeButtons = self.planTypes.map {
+            let button = PlanTypeButton(planType: $0)
+            button.addTarget(self, action: #selector(onPlanTypeTapped(_:)), for: .touchUpInside)
+            return button
+        }
+        planTypeButtons.forEach {
+            stackView.addArrangedSubview($0)
+        }
+        self.planTypeButtons = planTypeButtons
+    }
+    
+    @objc private func onPlanTypeTapped(_ sender: PlanTypeButton) {
+        let planType = sender.planType
+        self.selectionHandler?(planType)
+    }
+    
+    func configure(selectedPlanType: PlanType) {
+        self.planTypeButtons.forEach {
+            $0.updateSelection(selectedPlanType: selectedPlanType)
+        }
+    }
+    
+}
+
+private final class PlanTypeButton: UIButton {
+    
+    let planType: PlanType
+    private var planTypeName: String {
+        switch self.planType {
+        case .memo: "메모"
+        case .book: "독서"
+        }
+    }
+    
+    init(planType: PlanType) {
+        self.planType = planType
+        super.init(frame: .zero)
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.setTitle(self.planTypeName, for: .normal)
+        self.setTitleColor(.white, for: .normal)
+        self.widthAnchor.constraint(equalToConstant: 90).isActive = true
+        self.heightAnchor.constraint(equalToConstant: 32).isActive = true
+        self.backgroundColor = UIColor.init(white: 0.1, alpha: 0.1)
+        self.layer.cornerRadius = 16
+        self.layer.borderWidth = 0.5
+        self.layer.borderColor = UIColor.white.cgColor
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func updateSelection(selectedPlanType: PlanType) {
+        self.backgroundColor = self.planType == selectedPlanType ? .black : .systemGray5
+    }
+}

--- a/MyLibrary/ViewModel/Model/HomeSection.swift
+++ b/MyLibrary/ViewModel/Model/HomeSection.swift
@@ -4,8 +4,9 @@
 //
 //  Created by 박세라 on 4/1/24.
 //
-import RxDataSources
+import Model
 import Foundation
+import RxDataSources
 
 // TODO: Header 추가
 public struct HomeSection {
@@ -21,9 +22,10 @@ public struct HomeSection {
 }
 public enum HomeSectionItem {
     case defaultCell(TodoListCellReactor)
+    case categoryCell([String])
+    case planTypesCell(PlanType)
     case bookCell(BookListCellReactor)
     case memoCell(MemoListCellReactor)
-    case categoryCell([String])
     // ...
 }
 


### PR DESCRIPTION
### Implement PlanTypesCell.

- 제 개인적인 스타일을 그대로 따르라고 하고 싶진 않은데, View나 Cell 구현에 약간 패턴이 덜 잡힌 것 같아서 샘플 삼아 구현해보았습니다.
- `UIKit`에서 custom view를 작성할 때에는 왠만하면 `final`을 항상 붙이도록 합니다.
- 일단 위에서 아래로 View가 초기화되는 순서에 따라 코드를 읽을 수 있도록 작성하였습니다. 호출 순서를 따르기도 하는데, `PlanTypesCell`의 경우에는 `init()` -> `setupViews()` -> `onPlanTypeTapped()` -> `configure()` 순서로 작성한 것도 의도적인 것입니다.
- `CategoryCell.handleSegmentedControlButtons()`를 직접 호출하는 것은 피해야합니다. 이 때문에 `selectedHandler`를 nil로 초기화했다가 다시 assign하는 코드가 필요하기도 했습니다. BackgroundColor를 변경하는 부분을 함수로 추출해서 사용했어야 합니다.
- 이번 PR에서 `HomeViewReactor.Mutation.update()`에 `selectedPlanType`을 추가한 것은 썩 좋은 접근은 아닌데, `HomeSection`을 `HomeViewReactor`에서 생성하고 있기 때문에 현재로선 어쩔 수 없을 것 같습니다. 추후에 좀 더 개선하도록 하겠습니다.
