### PR TITLE
Improve HomeSection and memo index problem.

### DIFF
--- a/MyLibrary/Common/UIKit+Extension.swift
+++ b/MyLibrary/Common/UIKit+Extension.swift
@@ -20,12 +20,20 @@ extension UIView: HasTypeName {
 // MARK: UICollectionView
 extension UICollectionView {
     package func register<T: UICollectionViewCell>(_ cellClass: T.Type) {
-    self.register(cellClass, forCellWithReuseIdentifier: T.typeName)
-  }
-  
+        self.register(cellClass, forCellWithReuseIdentifier: T.typeName)
+    }
+    
     package func dequeueReusableCell<T: UICollectionViewCell>(_ cellClass: T.Type, for indexPath: IndexPath) -> T {
-    return self.dequeueReusableCell(withReuseIdentifier: T.typeName, for: indexPath) as! T
-  }
+        return self.dequeueReusableCell(withReuseIdentifier: T.typeName, for: indexPath) as! T
+    }
+    
+    package func registerHeader<T: UICollectionReusableView>(_ viewClass: T.Type) {
+        self.register(viewClass, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: T.typeName)
+    }
+    
+    package func dequeueReusableView<T: UICollectionReusableView>(_ cellClass: T.Type, kind: String, for indexPath: IndexPath) -> T {
+        return self.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: T.typeName, for: indexPath) as! T
+    }
 }
 
 // MARK: UIView

--- a/MyLibrary/Model/Memo.swift
+++ b/MyLibrary/Model/Memo.swift
@@ -9,7 +9,9 @@ import Foundation
 
 public struct Memo {
     
-    public let memoID: Int32
+    public typealias ID = Int32
+    
+    public let memoID: ID
     public var content: String
     
     public init(memoID: Int32, content: String) {

--- a/MyLibrary/Package.swift
+++ b/MyLibrary/Package.swift
@@ -18,7 +18,6 @@ let package = Package(
                 "RepositoryImp",
                 "ViewModel",
                 "View",
-                "Common",
             ]
         ),
         .library(
@@ -28,6 +27,10 @@ let package = Package(
         .library(
             name: "Repository",
             targets: ["Repository", "RepositoryImp"]
+        ),
+        .library(
+            name: "View",
+            targets: ["View"]
         ),
         .library(
             name: "ViewModel",
@@ -41,8 +44,7 @@ let package = Package(
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.0.0")),
         .package(url: "https://github.com/RxSwiftCommunity/RxDataSources.git", from: "5.0.0"),
         .package(url: "https://github.com/roberthein/TinyConstraints", .upToNextMajor(from: "4.0.1")),
-        .package(url: "https://github.com/ccgus/fmdb",
-            .upToNextMinor(from: "2.7.8")),
+        .package(url: "https://github.com/ccgus/fmdb", .upToNextMinor(from: "2.7.8")),
     ],
 
     targets: [
@@ -72,9 +74,9 @@ let package = Package(
         .target(
             name: "View",
             dependencies: [
+                "Common",
                 "Model",
                 "Repository",
-                "RepositoryImp", // Temporal Import
                 "ViewModel",
                 .product(name: "Alamofire", package: "Alamofire"),
                 .product(name: "ReactorKit", package: "ReactorKit"),
@@ -89,6 +91,7 @@ let package = Package(
         .target(
             name: "ViewModel",
             dependencies: [
+                "Common",
                 "Model",
                 "Repository",
                 .product(name: "ReactorKit", package: "ReactorKit"),

--- a/MyLibrary/View/HomeViewController/HeaderCell.swift
+++ b/MyLibrary/View/HomeViewController/HeaderCell.swift
@@ -6,50 +6,49 @@
 //
 
 import UIKit
-import ReactorKit
-import RxSwift
-import RxCocoa
-import ViewModel
 
-class HeaderCell: UICollectionReusableView, View {
+class HeaderCell: UICollectionViewCell {
     
-    typealias Reactor = HeaderCellReactor
-    
-    // MARK: - Property
-    var disposeBag = DisposeBag()
-    
-    // MARK: - view
-    let titleLabel = UILabel()
-    
-    var addButton = UIButton()
-    // ...
+    private weak var titleLabel: UILabel!
+    private weak var addButton: UIButton!
+    private var addTapped: (() -> Void)?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
-        self.addSubview(titleLabel)
-        self.addSubview(addButton)
-        
-        titleLabel.numberOfLines = 0
-        titleLabel.font = UIFont.systemFont(ofSize: 24, weight: .bold)
-        titleLabel.left(to: self, offset: 8)
-        titleLabel.centerYToSuperview()
-        
-        addButton.setImage(UIImage(systemName: "plus.app"), for: .normal)
-        addButton.height(20)
-        addButton.width(20)
-        addButton.centerYToSuperview()
-        addButton.right(to: self, offset: -8)
-        
+        self.setupSubviews()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func bind(reactor: HeaderCellReactor) {
+    private func setupSubviews() {
+        let titleLabel = UILabel()
+        titleLabel.numberOfLines = 0
+        titleLabel.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        self.addSubview(titleLabel)
+        titleLabel.leadingToSuperview(offset: 16)
+        titleLabel.centerYToSuperview()
+        self.titleLabel = titleLabel
         
-        titleLabel.text = reactor.initialState.headerTitle
-        
+        let addButton = UIButton()
+        addButton.setImage(UIImage(systemName: "plus.app"), for: .normal)
+        addButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
+        self.addSubview(addButton)
+        addButton.width(20)
+        addButton.height(20)
+        addButton.trailingToSuperview(offset: 16)
+        addButton.centerYToSuperview()
+        self.addButton = addButton
+    }
+    
+    func configure(with title: String, addTapped: (() -> Void)?) {
+        self.titleLabel.text = title
+        self.addTapped = addTapped
+        self.addButton.isHidden = addTapped == nil
+    }
+    
+    @objc private func addButtonTapped() {
+        self.addTapped?()
     }
 }

--- a/MyLibrary/View/HomeViewController/HeaderCell.swift
+++ b/MyLibrary/View/HomeViewController/HeaderCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class HeaderCell: UICollectionViewCell {
+class HeaderCell: UICollectionReusableView {
     
     private weak var titleLabel: UILabel!
     private weak var addButton: UIButton!
@@ -15,6 +15,7 @@ class HeaderCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        self.backgroundColor = .systemBackground
         self.setupSubviews()
     }
     

--- a/MyLibrary/View/HomeViewController/HomeViewController.swift
+++ b/MyLibrary/View/HomeViewController/HomeViewController.swift
@@ -47,7 +47,7 @@ public class HomeViewController: UICollectionViewController, MemoListCellDelegat
             return cell
         case let .memo(memo):
             let cell = collectionView.dequeueReusableCell(MemoListCell.self, for: indexPath)
-            cell.configure(with: memo.content)
+            cell.configure(with: memo)
             cell.delegate = self
             return cell
         case let .book(reactor):
@@ -198,10 +198,8 @@ public class HomeViewController: UICollectionViewController, MemoListCellDelegat
     }
     
     // MARK: - MemoListCellDelegate
-    func memoListCellDeleteTapped(of cell: MemoListCell) {
-        guard let indexPath = self.collectionView.indexPath(for: cell) else { return }
-        let memo = self.state.memos[indexPath.item - 1]
-        self.reactor.action.onNext(.deleteMemo(memo))
+    func memoListCellDeleteTapped(memoID: Memo.ID) {
+        self.reactor.action.onNext(.deleteMemo(memoID))
     }
 }
 

--- a/MyLibrary/View/HomeViewController/MemoListCell.swift
+++ b/MyLibrary/View/HomeViewController/MemoListCell.swift
@@ -5,17 +5,19 @@
 //  Created by 박세라 on 5/21/24.
 //
 
+import Model
 import UIKit
 
 protocol MemoListCellDelegate: AnyObject {
-    func memoListCellDeleteTapped(of cell: MemoListCell)
+    func memoListCellDeleteTapped(memoID: Memo.ID)
 }
 
 class MemoListCell: UICollectionViewCell {
-
+    
     private weak var contentLabel: UILabel!
     private weak var baseView: UIView!
-    
+
+    private var memoID: Memo.ID!
     weak var delegate: MemoListCellDelegate?
     
     override init(frame: CGRect) {
@@ -58,14 +60,15 @@ class MemoListCell: UICollectionViewCell {
         deleteButton.centerYToSuperview()
     }
     
-    func configure(with memoContent: String) {
+    func configure(with memo: Memo) {
         self.layer.cornerRadius = 4
         self.baseView.layer.cornerRadius = 4
-        self.contentLabel.text = memoContent
+        self.memoID = memo.memoID
+        self.contentLabel.text = memo.content
     }
     
     @objc private func deleteTapped() {
-        self.delegate?.memoListCellDeleteTapped(of: self)
+        self.delegate?.memoListCellDeleteTapped(memoID: self.memoID)
     }
 }
     

--- a/MyLibrary/ViewModel/HomeViewReactor.swift
+++ b/MyLibrary/ViewModel/HomeViewReactor.swift
@@ -120,59 +120,15 @@ public class HomeViewReactor: Reactor {
                 newState.selectedPlanType = planType
             }
             
-            let todoHeader = HomeSectionItem.title("Todo")
             let todoItems = newState.todos.map { HomeSectionItem.todo(TodoListCellReactor(state: $0)) }
-            let planHeader = HomeSectionItem.title("Plan")
-            let playTypesItem = HomeSectionItem.planType(newState.selectedPlanType)
-            let memoItems = newState.memos.map { HomeSectionItem.memo($0) }
-            let bookItems = newState.books.map { HomeSectionItem.book(BookListCellReactor(state: $0)) }
-            
-            var sections = [HomeSection]()
-            sections.append(HomeSection(items: [todoHeader]))
-            sections.append(HomeSection(items: todoItems))
-            sections.append(HomeSection(items: [planHeader]))
-            sections.append(HomeSection(items: [playTypesItem]))
-            switch newState.selectedPlanType {
-            case .memo: sections.append(HomeSection(items: memoItems))
-            case .book: sections.append(HomeSection(items: bookItems))
+            let planTypesItem = HomeSectionItem.planType(newState.selectedPlanType)
+            let planItems: [HomeSectionItem] = switch newState.selectedPlanType {
+            case .memo: newState.memos.map { HomeSectionItem.memo($0) }
+            case .book: newState.books.map { HomeSectionItem.book(BookListCellReactor(state: $0)) }
             }
-            
-            
-//            
-//            let plans: [Plan]
-//            switch newState.selectedPlanType {
-//            case .memo: plans = newState.memos.map { Plan(memo: $0) }
-//            case .book: plans = newState.books.map { Plan(book: $0) }
-//            }
-//            
-//            
-//            let todoCells = todos.map {
-//                HomeSectionItem.defaultCell(TodoListCellReactor(state: $0))
-//            }
-//            let planCells = plans.map { plan -> HomeSectionItem in
-//                switch plan {
-//                case .memo(let memo):
-//                    // Memo 객체의 정보를 사용
-//                    return HomeSectionItem.memoCell(memo)
-//                case .book(let book):
-//                    // Book 객체의 정보를 사용
-//                    return HomeSectionItem.bookCell(BookListCellReactor(state: book))
-//                }
-//            }
-//            
-//            // TODO: Category도 Model화 작업 예정.
-//            var categoryCells = [HomeSectionItem.planTypesCell(newState.selectedPlanType)]
-//            
-//            categoryCells.append(contentsOf: planCells)
-//            
-//            let todoList = HomeSection(header: "Todo", items: todoCells)
-//            let planTypes = HomeSection(header: "Plan", items: [HomeSectionItem.planTypesCell(newState.selectedPlanType)])
-//            let planList = HomeSection(header: "", items: planCells)
-//            
-//            sections.append(todoList)
-//            sections.append(planTypes)
-//            sections.append(planList)
-            
+            var sections = [HomeSection]()
+            sections.append(HomeSection(id: .todo, header: "Todo", items: todoItems))
+            sections.append(HomeSection(id: .plan, header: "Plan", items: [planTypesItem] + planItems))
             newState.sections = sections
         case .updateBook(let bookView):
             newState.bookView = bookView

--- a/MyLibrary/ViewModel/HomeViewReactor.swift
+++ b/MyLibrary/ViewModel/HomeViewReactor.swift
@@ -32,7 +32,7 @@ public class HomeViewReactor: Reactor {
         case addMemo(String)
         case addBook(Book)
         case updateBook(Book)
-        case deleteMemo(Memo)
+        case deleteMemo(Memo.ID)
     }
     
     public enum Mutation {
@@ -96,8 +96,8 @@ public class HomeViewReactor: Reactor {
         case .addBook(let book):
             _ = self.bookRepository.create(book: book)
             return self.fetchAll(with: .book)
-        case let .deleteMemo(memo):
-            _ = memoRepository.delete(with: memo.memoID)
+        case let .deleteMemo(memoID):
+            _ = memoRepository.delete(with: memoID)
             return self.fetchAll(with: .memo)
         }
     }

--- a/MyLibrary/ViewModel/HomeViewReactor.swift
+++ b/MyLibrary/ViewModel/HomeViewReactor.swift
@@ -119,37 +119,59 @@ public class HomeViewReactor: Reactor {
             if let planType = planType {
                 newState.selectedPlanType = planType
             }
-            let plans: [Plan]
-            switch newState.selectedPlanType {
-            case .memo: plans = newState.memos.map { Plan(memo: $0) }
-            case .book: plans = newState.books.map { Plan(book: $0) }
-            }
+            
+            let todoHeader = HomeSectionItem.title("Todo")
+            let todoItems = newState.todos.map { HomeSectionItem.todo(TodoListCellReactor(state: $0)) }
+            let planHeader = HomeSectionItem.title("Plan")
+            let playTypesItem = HomeSectionItem.planType(newState.selectedPlanType)
+            let memoItems = newState.memos.map { HomeSectionItem.memo($0) }
+            let bookItems = newState.books.map { HomeSectionItem.book(BookListCellReactor(state: $0)) }
+            
             var sections = [HomeSection]()
-            
-            let todoCells = todos.map {
-                HomeSectionItem.defaultCell(TodoListCellReactor(state: $0))
-            }
-            let planCells = plans.map { plan -> HomeSectionItem in
-                switch plan {
-                case .memo(let memo):
-                    // Memo 객체의 정보를 사용
-                    return HomeSectionItem.memoCell(memo)
-                case .book(let book):
-                    // Book 객체의 정보를 사용
-                    return HomeSectionItem.bookCell(BookListCellReactor(state: book))
-                }
+            sections.append(HomeSection(items: [todoHeader]))
+            sections.append(HomeSection(items: todoItems))
+            sections.append(HomeSection(items: [planHeader]))
+            sections.append(HomeSection(items: [playTypesItem]))
+            switch newState.selectedPlanType {
+            case .memo: sections.append(HomeSection(items: memoItems))
+            case .book: sections.append(HomeSection(items: bookItems))
             }
             
-            // TODO: Category도 Model화 작업 예정.
-            var categoryCells = [HomeSectionItem.planTypesCell(newState.selectedPlanType)]
             
-            categoryCells.append(contentsOf: planCells)
-            
-            let todoList = HomeSection(header: "Todo", items: todoCells)
-            let planList = HomeSection(header: "Plan", items: categoryCells)
-            
-            sections.append(todoList)
-            sections.append(planList)
+//            
+//            let plans: [Plan]
+//            switch newState.selectedPlanType {
+//            case .memo: plans = newState.memos.map { Plan(memo: $0) }
+//            case .book: plans = newState.books.map { Plan(book: $0) }
+//            }
+//            
+//            
+//            let todoCells = todos.map {
+//                HomeSectionItem.defaultCell(TodoListCellReactor(state: $0))
+//            }
+//            let planCells = plans.map { plan -> HomeSectionItem in
+//                switch plan {
+//                case .memo(let memo):
+//                    // Memo 객체의 정보를 사용
+//                    return HomeSectionItem.memoCell(memo)
+//                case .book(let book):
+//                    // Book 객체의 정보를 사용
+//                    return HomeSectionItem.bookCell(BookListCellReactor(state: book))
+//                }
+//            }
+//            
+//            // TODO: Category도 Model화 작업 예정.
+//            var categoryCells = [HomeSectionItem.planTypesCell(newState.selectedPlanType)]
+//            
+//            categoryCells.append(contentsOf: planCells)
+//            
+//            let todoList = HomeSection(header: "Todo", items: todoCells)
+//            let planTypes = HomeSection(header: "Plan", items: [HomeSectionItem.planTypesCell(newState.selectedPlanType)])
+//            let planList = HomeSection(header: "", items: planCells)
+//            
+//            sections.append(todoList)
+//            sections.append(planTypes)
+//            sections.append(planList)
             
             newState.sections = sections
         case .updateBook(let bookView):

--- a/MyLibrary/ViewModel/Model/HomeSection.swift
+++ b/MyLibrary/ViewModel/Model/HomeSection.swift
@@ -8,25 +8,16 @@ import Model
 import Foundation
 import RxDataSources
 
-// TODO: Header 추가
 public struct HomeSection {
-    public var header: String
     public var items: [HomeSectionItem]
-    public var identity: String
-    
-    public init(header: String, items: [HomeSectionItem]) {
-        self.header = header
-        self.items = items
-        self.identity = UUID().uuidString
-    }
 }
+
 public enum HomeSectionItem {
-    case defaultCell(TodoListCellReactor)
-    case categoryCell([String])
-    case planTypesCell(PlanType)
-    case bookCell(BookListCellReactor)
-    case memoCell(Memo)
-    // ...
+    case title(String)
+    case todo(TodoListCellReactor)
+    case planType(PlanType)
+    case memo(Memo)
+    case book(BookListCellReactor)
 }
 
 extension HomeSection: SectionModelType {

--- a/MyLibrary/ViewModel/Model/HomeSection.swift
+++ b/MyLibrary/ViewModel/Model/HomeSection.swift
@@ -9,11 +9,16 @@ import Foundation
 import RxDataSources
 
 public struct HomeSection {
+    public enum ID: Int {
+        case todo
+        case plan
+    }
+    public var id: ID
+    public var header: String
     public var items: [HomeSectionItem]
 }
 
 public enum HomeSectionItem {
-    case title(String)
     case todo(TodoListCellReactor)
     case planType(PlanType)
     case memo(Memo)


### PR DESCRIPTION
### Improve HomeSection and memo index problem.

- 모든 요소를 section으로 정의했던 구현을 다시 원복해서, `Todo`와 `Plan` section 2개로 구현하도록 다시 변경해보았습니다.
- DeleteMemo에서 문제가 되었던 index 방식의 문제를 회피하고자, memoID를 기준으로 하는 방식을 사용해보았습니다.
- `sectionHeadersPinToVisibleBounds`를 설정해, header view가 스크롤 시 상단에 pinning 되도록 변경하였습니다.